### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+arch:
+ - amd64
+ - ppc64le
+ 
 sudo: false
 
 env:
@@ -10,6 +14,14 @@ env:
     - LUA="luajit @"
     - LUA="luajit 2.0"
     - LUA="luajit 2.1"
+jobs:
+  exclude:
+    - arch: ppc64le
+      env: LUA="luajit @"
+    - arch: ppc64le
+      env: LUA="luajit 2.0"
+    - arch: ppc64le
+      env: LUA="luajit 2.1"
 
 before_install:
   - pip install hererocks


### PR DESCRIPTION
Add support for architecture ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
Added ppc64le arch and excluded  env for luajit @, luajit 2.0 and luajit 2.1 ppc64le arch